### PR TITLE
Update admin.py

### DIFF
--- a/src/piaf/admin.py
+++ b/src/piaf/admin.py
@@ -19,7 +19,7 @@ class ParagraphBatchAdmin(admin.ModelAdmin):
 class ParagraphAdmin(admin.ModelAdmin):
     list_display = ('article', 'batch', 'text', 'status')
     ordering = ('article',)
-    search_fields = ('name',)
+    search_fields = ('text',)
 
 
 class QuestionAdmin(admin.ModelAdmin):


### PR DESCRIPTION
remplacement de "name" par "text" (à la ligne 22) dans le fichier /src/piaf/admin.py
car j'avais cette erreur : 


Request Method: | GET
-- | --
http://127.0.0.1:8000/admin/piaf/paragraph/?q=recherche+de+paragraphe+
2.1
FieldError
Cannot resolve keyword 'name' into field. Choices are: article, article_id, batch, batch_id, id, questions, status, text, user, user_id
/src/venv/lib/python3.6/site-packages/django/db/models/sql/query.py in names_to_path, line 1389
/src/venv/bin/python3
3.6.10
['/src/src',  '/src',  '/',  '/src/venv/bin',  '/usr/local/lib/python36.zip',  '/usr/local/lib/python3.6',  '/usr/local/lib/python3.6/lib-dynload',  '/src/venv/lib/python3.6/site-packages',  '../api']
ven, 18 Sep 2020 11:59:13 +0000



et cela a fonctionné 